### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+# Fix line endings for all text files
+# Stops Git from thinking the whole file changed due to OS differences
+* text=auto
+
+# Gradle wrapper script must use LF for Linux/macOS/CI
+backend/gradlew text eol=lf
+
+# Windows command scripts should use CRLF
+backend/*.bat text eol=crlf
+
+# Binary files, don't line normalize
+*.jar binary
+*.png binary
+*.jpg binary
+*.jpeg binary

--- a/backend/.gitattributes
+++ b/backend/.gitattributes
@@ -1,3 +1,0 @@
-/gradlew text eol=lf
-*.bat text eol=crlf
-*.jar binary


### PR DESCRIPTION
- moved it to the root
- added that it shouldn't normalize images for when we add them in the future.
- set text=auto so line endings stay consistent across OSes and git won't show false changes

This is a separate commit before editing help.md to avoid false diffs in that branch