### PR TITLE
Add game statistic components

### DIFF
--- a/web/src/components/GameStats.vue
+++ b/web/src/components/GameStats.vue
@@ -1,0 +1,33 @@
+<template>
+  <v-sheet class="blur rounded-lg pl-6 pr-6 pt-4 pb-4">
+    <dl class="d-flex flex-row ga-8 text-right">
+      <StatItem label="Timer" :value="formattedTime" />
+      <StatItem label="Round" :value="formattedRounds" />
+      <StatItem label="Score" :value="score" />
+    </dl>
+  </v-sheet>
+</template>
+
+<script lang="ts" setup>
+  const props = defineProps<{
+    timeSeconds: number
+    round: number
+    totalRounds: number
+    score: number
+  }>()
+
+  const formattedTime = computed(() => {
+    const minutes = Math.floor(props.timeSeconds / 60)
+    const seconds = props.timeSeconds % 60
+    return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`
+  })
+
+  const formattedRounds = computed(() => `${props.round}/${props.totalRounds}`)
+</script>
+
+<style scoped>
+.blur{
+  backdrop-filter: blur(6px);
+  background: rgba(0,0,0,.25);
+}
+</style>

--- a/web/src/components/StatItem.vue
+++ b/web/src/components/StatItem.vue
@@ -1,0 +1,17 @@
+<template>
+  <div class="d-flex flex-column">
+    <dt class="text-caption text-medium-emphasis">
+      {{ label }}
+    </dt>
+    <dd class="text-h5 font-weight-bold">
+      {{ value }}
+    </dd>
+  </div>
+</template>
+
+<script lang="ts" setup>
+  defineProps<{
+    label: string
+    value: string
+  }>()
+</script>


### PR DESCRIPTION
### What changed
Added two components to display game statistics (time, round, score). See the gif below

![demo - GameStats](https://github.com/user-attachments/assets/8b1f6f59-5f62-49ba-b189-52ef1970cbf6)

### Why it changed
We don't have a way to display game stats yet

### How to test
n/a