### PR TITLE
Add home link logo component

### DIFF
--- a/web/src/components/HomeLinkLogo.vue
+++ b/web/src/components/HomeLinkLogo.vue
@@ -1,0 +1,23 @@
+<template>
+  <RouterLink class="logo" to="/">
+    UMG!
+  </RouterLink>
+</template>
+
+<style scoped>
+.logo{
+  color: white;
+  font-size: 80px;
+  font-weight: 900;
+  line-height: 1;
+  text-decoration: none;
+  text-shadow:
+    0 2px 8px rgba(0,0,0,.6),
+    0 0 1px rgba(0,0,0,.9);
+  transition: color .15s ease;
+}
+
+.logo:hover{
+  color:#2196f3;
+}
+</style>


### PR DESCRIPTION
### What changed
Added a logo component. When the user clicks on it, they go to the home page. See the video below

https://github.com/user-attachments/assets/149cba8a-2def-476f-8e14-0f03dd3a8eb3

### Why it changed
To display the app logo that doubles as a link to the home page (a prettier "exit game" button)

### How to test
n/a