### PR TITLE
Add initial game page

### DIFF
--- a/web/src/pages/game/[gameId].vue
+++ b/web/src/pages/game/[gameId].vue
@@ -51,8 +51,8 @@
     },
     {
       imageUrl: 'https://uman-beings.github.io/UMG-Pictures/IMG_3652.jpg',
-      lat: 1234,
-      lng: 1517,
+      lat: 1172,
+      lng: 1776,
     },
     {
       imageUrl: 'https://uman-beings.github.io/UMG-Pictures/IMG_3655.jpg',


### PR DESCRIPTION
### What changed
Added the initial Game page. This page currently contains game logic and hard-coded locations for demo purposes. These will be removed once the API is ready.

The page renders the following UI components by phase:

#### All phases
- UMG! Logo

#### GUESS phase
- Game statistics (timer, round, total rounds, score)
- Image (closes #64)
- Guessing map 

#### REVEAL phase
- Game statistics 
- Guess results (score received)
- Location reveal map
 
#### FINISHED phase
- Simple final score

#### Demo
https://github.com/user-attachments/assets/b0b5aefe-2bed-45a8-846a-ff6612e6dca2

### How to test
1. `cd web`
2. `pnpm install` (if you havent already installed Leaflet and other dependencies)
3. `pnpm dev`
4. Open your web browser and go to `localhost:3000/game/(any value)`