### PR TITLE
Bug fix: ensure Leaflet markers display in production

### DIFF
--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -11,7 +11,7 @@
 # Remove prod containers, network, and volumes
 # docker-compose -f docker-compose.prod.yaml -p umg_prod down -v
 
-# App URL (frontend + proxied API): http://localhost:7000
+# App URL (frontend + proxied API): http://localhost:7000/game/test
 
 services:
   db_umg:

--- a/web/src/map/useLeafletImageMap.ts
+++ b/web/src/map/useLeafletImageMap.ts
@@ -2,6 +2,15 @@ import type { ImageMapConfig } from '@/map/imageMapConfig'
 import L from 'leaflet'
 import { onBeforeUnmount, onMounted, ref, type Ref } from 'vue'
 import 'leaflet/dist/leaflet.css'
+import markerIcon2x from 'leaflet/dist/images/marker-icon-2x.png'
+import markerIcon from 'leaflet/dist/images/marker-icon.png'
+import markerShadow from 'leaflet/dist/images/marker-shadow.png'
+
+L.Icon.Default.mergeOptions({
+  iconRetinaUrl: markerIcon2x,
+  iconUrl: markerIcon,
+  shadowUrl: markerShadow,
+})
 
 export function useLeafletImageMap (mapDiv: Ref<HTMLDivElement | null>, imageMapConfig: ImageMapConfig) {
   const map = ref<L.Map | null>(null)


### PR DESCRIPTION
Bug Fix: leaflet marker image assets was not loading when selecting location for a guess 

- Leaflet default marker icons broke in prod builds because asset URLs differ from dev
- Fixed by importing marker assets and overriding default Leaflet icon URLs