### PR TITLE
Add .pnpm-store to .gitignore

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.pnpm-store
 node_modules
 
 # local env files


### PR DESCRIPTION
### What changed
Added .pnpm-store to web/.gitignore

 (If you're using VS Code and .pnpm-store exists, it should now be greyed out)
<img width="253" height="92" alt="image" src="https://github.com/user-attachments/assets/64427216-ce87-4cb6-8b3b-b193fff8a18f" />

### Why it changed
To prevent git from tracking 1000+ files (~200MB) in .pnpm-store after running `docker-compose -f docker-compose.dev.yaml -p umg_dev up --build`

### How to test
1. Add .pnpm-store to web/.gitignore
2. Run `docker-compose -f docker-compose.dev.yaml -p umg_dev up --build`

git should not be tracking any files under .pnpm-store

