### PR TITLE
Add location seeding for dev profile

### DIFF
--- a/backend/src/main/java/com/umanbeing/umg/configs/DevSeedConfig.java
+++ b/backend/src/main/java/com/umanbeing/umg/configs/DevSeedConfig.java
@@ -1,0 +1,61 @@
+package com.umanbeing.umg.configs;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+import com.umanbeing.umg.models.Location;
+import com.umanbeing.umg.repos.LocationRepo;
+
+@Configuration
+@Profile("dev")
+public class DevSeedConfig {
+
+  @Bean
+  CommandLineRunner seedLocations(LocationRepo locationRepo) {
+    return args -> {
+      if (locationRepo.count() > 0) {
+        return;
+      }
+
+      locationRepo.saveAll(List.of(
+        new Location("", "https://uman-beings.github.io/UMG-Pictures/crazy-balance-v0-kzeho9rnepre1.jpeg",new BigDecimal("2282"), new BigDecimal("1340")),
+        new Location("", "https://uman-beings.github.io/UMG-Pictures/deer1.jpeg", new BigDecimal("2705"), new BigDecimal("833")),
+        new Location("", "https://uman-beings.github.io/UMG-Pictures/IMG_3651.jpg", new BigDecimal("1770"), new BigDecimal("1480")),
+        new Location("", "https://uman-beings.github.io/UMG-Pictures/IMG_3652.jpg", new BigDecimal("1679"), new BigDecimal("1173")),
+        new Location("", "https://uman-beings.github.io/UMG-Pictures/IMG_3655.jpg", new BigDecimal("1209"), new BigDecimal("1344")),
+
+        new Location("", "https://uman-beings.github.io/UMG-Pictures/56jes45xzfdg1.jpeg",new BigDecimal("2813"), new BigDecimal("1143")),
+        new Location("", "https://uman-beings.github.io/UMG-Pictures/by35nk00kzcg1.jpeg", new BigDecimal("2718"), new BigDecimal("1065")),
+        new Location("", "https://uman-beings.github.io/UMG-Pictures/IMG_3659.jpg", new BigDecimal("1259"), new BigDecimal("1158")),
+        new Location("", "https://uman-beings.github.io/UMG-Pictures/IMG_3660.jpeg", new BigDecimal("1545"), new BigDecimal("1210")),
+        new Location("", "https://uman-beings.github.io/UMG-Pictures/IMG_3662.jpg", new BigDecimal("2476"), new BigDecimal("1350")),
+
+        new Location("", "https://uman-beings.github.io/UMG-Pictures/IMG_3663.jpeg",new BigDecimal("2785"), new BigDecimal("1665")),
+        new Location("", "https://uman-beings.github.io/UMG-Pictures/IMG_3665.jpg", new BigDecimal("2774"), new BigDecimal("1756")),
+        new Location("", "https://uman-beings.github.io/UMG-Pictures/IMG_3670.jpg", new BigDecimal("3237"), new BigDecimal("1684")),
+        new Location("", "https://uman-beings.github.io/UMG-Pictures/IMG_3673.jpg", new BigDecimal("3228"), new BigDecimal("1694")),
+        new Location("", "https://uman-beings.github.io/UMG-Pictures/IMG_3675.jpg", new BigDecimal("2476"), new BigDecimal("1350")),
+
+        new Location("", "https://uman-beings.github.io/UMG-Pictures/IMG_3675.jpg",new BigDecimal("2719"), new BigDecimal("1942")),
+        new Location("", "https://uman-beings.github.io/UMG-Pictures/IMG_3676.jpeg", new BigDecimal("2688"), new BigDecimal("1992")),
+        new Location("", "https://uman-beings.github.io/UMG-Pictures/IMG_3678.jpg", new BigDecimal("2301"), new BigDecimal("2303")),
+        new Location("", "https://uman-beings.github.io/UMG-Pictures/IMG_3680.jpeg", new BigDecimal("2068"), new BigDecimal("2109")),
+        new Location("", "https://uman-beings.github.io/UMG-Pictures/IMG_3689.jpg", new BigDecimal("1966"), new BigDecimal("2150")),
+
+        new Location("", "https://uman-beings.github.io/UMG-Pictures/IMG_3696.jpg",new BigDecimal("2044"), new BigDecimal("1728")),
+        new Location("", "https://uman-beings.github.io/UMG-Pictures/IMG_3697.jpg", new BigDecimal("2206"), new BigDecimal("1668")),
+        new Location("", "https://uman-beings.github.io/UMG-Pictures/IMG_3698.jpg", new BigDecimal("2387"), new BigDecimal("1787")),
+        new Location("", "https://uman-beings.github.io/UMG-Pictures/IMG_3702.jpg", new BigDecimal("2722"), new BigDecimal("1070")),
+        new Location("", "https://uman-beings.github.io/UMG-Pictures/IMG_3706.jpeg", new BigDecimal("2955"), new BigDecimal("923")),
+
+        new Location("", "https://uman-beings.github.io/UMG-Pictures/IMG_3712.jpg",new BigDecimal("3438"), new BigDecimal("815")),
+        new Location("", "https://uman-beings.github.io/UMG-Pictures/lol-v0-lf22qalq7ryf1.jpeg", new BigDecimal("811"), new BigDecimal("963"))
+      ));
+    };
+  }
+}

--- a/backend/src/main/java/com/umanbeing/umg/models/Location.java
+++ b/backend/src/main/java/com/umanbeing/umg/models/Location.java
@@ -3,12 +3,14 @@ package com.umanbeing.umg.models;
 import jakarta.persistence.*;
 import java.math.BigDecimal;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Entity
 @Table(name = "\"LOCATION\"")
 @Getter
 @Setter
+@NoArgsConstructor
 public class Location {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -26,4 +28,11 @@ public class Location {
 
     @Column(name = "\"corY\"", nullable = false, precision = 17, scale = 13)
     private BigDecimal corY;
+
+    public Location(String name, String imageUrl, BigDecimal corX, BigDecimal corY) {
+        this.name = name;
+        this.imageUrl = imageUrl;
+        this.corX = corX;
+        this.corY = corY;
+    }
 }


### PR DESCRIPTION
### What changed
Added a DevSeedConfig class for the dev profile that adds 27 locations to the database if none already exist

### Why it changed
To start a game, the database must have enough locations to meet the number of rounds requested

### How to test
First, clear existing dev db volumes to ensure an empty location table
`docker-compose -f docker-compose.dev.yaml -p umg_dev down -v`

Then, build and run the dev env
`docker-compose -f docker-compose.dev.yaml -p umg_dev up --build`

Once the setup is finished, the console should show multiple insertions into the location table
<img width="1365" height="523" alt="image" src="https://github.com/user-attachments/assets/727c692c-2ec0-46d9-9af3-c77b423d580f" />

Launch Postman and send a request to create a game with 20 rounds
<img width="905" height="500" alt="image" src="https://github.com/user-attachments/assets/019e007d-6b8b-4ddb-ac36-fe34129fb8cf" />

You should receive a valid response like the one in the screenshot above