### PR TITLE
Fix Leaflet marker icon path detection in Vite dev

### DIFF
--- a/web/src/map/useLeafletImageMap.ts
+++ b/web/src/map/useLeafletImageMap.ts
@@ -6,6 +6,10 @@ import markerIcon2x from 'leaflet/dist/images/marker-icon-2x.png'
 import markerIcon from 'leaflet/dist/images/marker-icon.png'
 import markerShadow from 'leaflet/dist/images/marker-shadow.png'
 
+if (import.meta.env.DEV) {
+  L.Icon.Default.imagePath = ""
+}
+
 L.Icon.Default.mergeOptions({
   iconRetinaUrl: markerIcon2x,
   iconUrl: markerIcon,


### PR DESCRIPTION
### What changed
Set L.Icon.Default.imagePath = "" in dev so Leaflet does not try to guess the path and instead uses the imported icons

### Why it changed
Leaflet can fail to detect the correct marker icon path when running in the Vite dev server.
<img width="364" height="365" alt="broken-markers-bef" src="https://github.com/user-attachments/assets/bdabe896-1c37-43ad-bcc9-66e90e076a73" />

Source: https://github.com/vitejs/vite-plugin-vue/discussions/104

### How to test
Run the dev env, start a game, and place a marker on the map. The map marker should be visible.
<img width="315" height="300" alt="fixed-markers" src="https://github.com/user-attachments/assets/a2983aec-067d-4961-89b0-f8c0679b7121" />
