### PR TITLE
Handle guesses on timeout if coords exist

### DIFF
--- a/web/src/components/GuessMap.vue
+++ b/web/src/components/GuessMap.vue
@@ -22,6 +22,7 @@
   import { useLeafletImageMap } from '@/map/useLeafletImageMap'
 
   const emits = defineEmits<{
+    (e: 'map-clicked', lat: number, lng: number): void,
     (e: 'guess', lat: number, lng: number): void
   }>()
 
@@ -30,8 +31,10 @@
   const guessMarker = ref<L.Marker | null>(null)
 
   watch(map, (mapInstance, _, onCleanup) => {
-    if (!mapInstance) return
-    
+    if (!mapInstance) {
+      return
+    }
+
     const minZoom = -1.9
     mapInstance.setMinZoom(minZoom)
     mapInstance.setMaxZoom(0)
@@ -47,6 +50,8 @@
         mapInstance.addLayer(marker)
         guessMarker.value = marker
       }
+
+      emits('map-clicked', latLng.lat, latLng.lng)
     }
 
     mapInstance.on('click', onMapClick)

--- a/web/src/pages/game/[gameId].vue
+++ b/web/src/pages/game/[gameId].vue
@@ -31,6 +31,7 @@
       />
       <GuessMap
         class="position-absolute bottom-0 right-0 ma-4"
+        @map-clicked="updateGuessCoordinates"
         @guess="submitGuess"
       />
     </div>
@@ -99,7 +100,11 @@
         timer.value++
 
         if (timeLimitSeconds > 0 && timer.value == timeLimitSeconds) {
-          timeout()
+          if (guessLat.value && guessLng.value) {
+            submitGuess(guessLat.value, guessLng.value)
+          } else {
+            timeout()
+          }
         }
       }
     }, 1000)


### PR DESCRIPTION
### What changed
Added logic to handle guesses when the timer runs out and the player has placed a map marker.
- GuessMap now emits a 'map-clicked' event with coordinates whenever (you guessed it) the player clicks the map
- The game page updates the current coordinates every time the map-clicked event fires
- When time runs out, we check the guess coordinates:
  - If they exist, that means the player has placed a map marker, so we submit a guess using those coordinates
  - If they do not exist, the player has not placed a map marker, so we send a timeout (a guess without coordinates)

### Why it changed
Even if the player has placed a guess marker, they might not be able to click the Submit button on time.

### How to test
1. Run the dev env
2. Go to localhost:3000
3. Start a game with a time limit
4. Place a marker on the guess map
5. Wait for time to run out (DO NOT click the submit button)

Your guess marker should appear on the reveal map.

https://github.com/user-attachments/assets/f7ab1a36-df23-4a86-aaa8-8c1775855348

