### PR TITLE
Correct dev seed location coordinates

### DIFF
--- a/backend/src/main/java/com/umanbeing/umg/configs/DevSeedConfig.java
+++ b/backend/src/main/java/com/umanbeing/umg/configs/DevSeedConfig.java
@@ -41,7 +41,7 @@ public class DevSeedConfig {
         new Location("", "https://uman-beings.github.io/UMG-Pictures/IMG_3673.jpg", new BigDecimal("3228"), new BigDecimal("1694")),
         new Location("", "https://uman-beings.github.io/UMG-Pictures/IMG_3675.jpg", new BigDecimal("2728"), new BigDecimal("1928")),
 
-        new Location("", "https://uman-beings.github.io/UMG-Pictures/IMG_3675.jpg",new BigDecimal("2719"), new BigDecimal("1942")),
+        new Location("", "https://uman-beings.github.io/UMG-Pictures/IMG_3712.jpg",new BigDecimal("3438"), new BigDecimal("815")),
         new Location("", "https://uman-beings.github.io/UMG-Pictures/IMG_3676.jpeg", new BigDecimal("2688"), new BigDecimal("1992")),
         new Location("", "https://uman-beings.github.io/UMG-Pictures/IMG_3678.jpg", new BigDecimal("2301"), new BigDecimal("2303")),
         new Location("", "https://uman-beings.github.io/UMG-Pictures/IMG_3680.jpeg", new BigDecimal("2068"), new BigDecimal("2109")),
@@ -52,8 +52,6 @@ public class DevSeedConfig {
         new Location("", "https://uman-beings.github.io/UMG-Pictures/IMG_3698.jpg", new BigDecimal("2387"), new BigDecimal("1787")),
         new Location("", "https://uman-beings.github.io/UMG-Pictures/IMG_3702.jpg", new BigDecimal("2722"), new BigDecimal("1070")),
         new Location("", "https://uman-beings.github.io/UMG-Pictures/IMG_3706.jpeg", new BigDecimal("2955"), new BigDecimal("923")),
-
-        new Location("", "https://uman-beings.github.io/UMG-Pictures/IMG_3712.jpg",new BigDecimal("3438"), new BigDecimal("815")),
         new Location("", "https://uman-beings.github.io/UMG-Pictures/lol-v0-lf22qalq7ryf1.jpeg", new BigDecimal("811"), new BigDecimal("963"))
       ));
     };


### PR DESCRIPTION
### What changed
- Corrected the coordinates of two locations in the dev seed config
  - closes #151 
- Deleted a duplicate location
  - closes #150

#### Affected locations/images:
IMG_3659
![IMG_3659](https://github.com/user-attachments/assets/b1ea914f-ade9-4940-93da-1deb44a13435)

IMG_3675
![IMG_3675](https://github.com/user-attachments/assets/ebc12c6a-b0ea-4523-9e78-44de8905d3eb)

### Why it changed
To correct late-night data entry errors and prevent the same image from appearing twice while playing the game

### How to test
1. Launch the dev env
2. Go to localhost:3000
3. Create a game with 20 rounds
4. Play until you encounter the two locations affected

Assuming you know where these pics were taken, they should now be where you expect them to be.