### PR TITLE
Add twelve seed locations

### DIFF
--- a/backend/src/main/java/com/umanbeing/umg/configs/DevSeedConfig.java
+++ b/backend/src/main/java/com/umanbeing/umg/configs/DevSeedConfig.java
@@ -52,7 +52,21 @@ public class DevSeedConfig {
         new Location("", "https://uman-beings.github.io/UMG-Pictures/IMG_3698.jpg", new BigDecimal("2387"), new BigDecimal("1787")),
         new Location("", "https://uman-beings.github.io/UMG-Pictures/IMG_3702.jpg", new BigDecimal("2722"), new BigDecimal("1070")),
         new Location("", "https://uman-beings.github.io/UMG-Pictures/IMG_3706.jpeg", new BigDecimal("2955"), new BigDecimal("923")),
-        new Location("", "https://uman-beings.github.io/UMG-Pictures/lol-v0-lf22qalq7ryf1.jpeg", new BigDecimal("811"), new BigDecimal("963"))
+        
+        new Location("", "https://uman-beings.github.io/UMG-Pictures/lol-v0-lf22qalq7ryf1.jpeg", new BigDecimal("811"), new BigDecimal("963")),
+
+        new Location("", "https://uman-beings.github.io/UMG-Pictures/IMG_3722.jpg", new BigDecimal("2228"), new BigDecimal("607")),
+        new Location("", "https://uman-beings.github.io/UMG-Pictures/IMG_3723.jpg", new BigDecimal("2319"), new BigDecimal("738")),
+        new Location("", "https://uman-beings.github.io/UMG-Pictures/IMG_3724.jpg", new BigDecimal("2394"), new BigDecimal("692")),
+        new Location("", "https://uman-beings.github.io/UMG-Pictures/IMG_3727.jpg", new BigDecimal("2467"), new BigDecimal("694")),
+        new Location("", "https://uman-beings.github.io/UMG-Pictures/IMG_3732.jpg", new BigDecimal("2246"), new BigDecimal("801")),
+        new Location("", "https://uman-beings.github.io/UMG-Pictures/IMG_3733.jpg", new BigDecimal("2245"), new BigDecimal("784")),
+        new Location("", "https://uman-beings.github.io/UMG-Pictures/IMG_3735.jpg", new BigDecimal("2009"), new BigDecimal("997")),
+        new Location("", "https://uman-beings.github.io/UMG-Pictures/IMG_3736.jpg", new BigDecimal("2015"), new BigDecimal("1172")),
+        new Location("", "https://uman-beings.github.io/UMG-Pictures/IMG_3740.jpg", new BigDecimal("2801"), new BigDecimal("1751")),
+        new Location("", "https://uman-beings.github.io/UMG-Pictures/IMG_3744.jpg", new BigDecimal("2904"), new BigDecimal("1741")),
+        new Location("", "https://uman-beings.github.io/UMG-Pictures/IMG_3745.jpg", new BigDecimal("2906"), new BigDecimal("1676")),
+        new Location("", "https://uman-beings.github.io/UMG-Pictures/IMG_3748.jpg", new BigDecimal("2882"), new BigDecimal("1001"))
       ));
     };
   }


### PR DESCRIPTION
### What changed
Adds twelve new locations to the dev locations seeder
- the locations are from this commit in our picture repo: https://github.com/UMan-Beings/UMG-Pictures/commit/521ee00fb64841e0ff66e889ed04475d5409ff61
- see #153 

### Why it changed
To increase campus coverage and image/location variety

### How to test
First, tear down the existing the DB volume
`docker-compose -f docker-compose.dev.yaml -p umg_dev down -v`

Then build and run the dev env
`docker-compose -f docker-compose.dev.yaml -p umg_dev up --build`

Once that's finished, go to localhost:3000

Start a game (preferably with 20 rounds to increase the chances of getting one of the new images)

You should see at least one of the pictures from this set: https://github.com/UMan-Beings/UMG-Pictures/commit/521ee00fb64841e0ff66e889ed04475d5409ff61
(unless you're incredibly unlucky)