### PR TITLE
Fix SonarQube analysis warnings by improving Java, TypeScript, and Git configuration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -95,7 +95,7 @@ jobs:
       - name: Run SonarQubeCloud analysis
         working-directory: backend
         run: >
-          ./gradlew sonarqube --no-daemon
+          ./gradlew sonar --no-daemon
           -Dsonar.organization=${{ secrets.SONAR_ORGANIZATION }}
           -Dsonar.token=${{ secrets.SONAR_TOKEN }}
           -Dsonar.host.url=https://sonarcloud.io

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,22 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          fetch-depth: 1 
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          version: 9
+          run_install: false
+
+      - name: Install frontend dependencies for Sonar
+        working-directory: web
+        run: pnpm install --frozen-lockfile
 
       # step 2: set up java 21 and cache gradle
       - name: Set up Java 21 and cache Gradle
@@ -76,15 +91,16 @@ jobs:
         working-directory: backend
         run: ./gradlew build --no-daemon
 
-      # step 6: SonarQubeCloud analysis (PRs, pushes to main, and manual runs)
-      - name: Run SonarQubeCloud scan
-        uses: SonarSource/sonarqube-scan-action@v7
-        with:
-          args: -Dsonar.organization=${{ secrets.SONAR_ORGANIZATION }}
+      # step 6: SonarQubeCloud analysis via Gradle (ensures Java classpath/libraries are provided)
+      - name: Run SonarQubeCloud analysis
+        working-directory: backend
+        run: >
+          ./gradlew sonarqube --no-daemon
+          -Dsonar.organization=${{ secrets.SONAR_ORGANIZATION }}
+          -Dsonar.token=${{ secrets.SONAR_TOKEN }}
+          -Dsonar.host.url=https://sonarcloud.io
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_HOST_URL: https://sonarcloud.io
 
   # build frontend container in CI, don't publish it.
   build-frontend-container:

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -4,6 +4,7 @@ plugins {
 	id 'info.solidsoft.pitest' version '1.19.0-rc.3'
 	id 'org.springframework.boot' version '4.0.2'
 	id 'io.spring.dependency-management' version '1.1.7'
+	id 'org.sonarqube' version '7.2.3.7755'
 }
 
 group = 'com.umanbeing'
@@ -64,6 +65,16 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testImplementation 'org.postgresql:postgresql:42.3.1'
 	pitest 'org.pitest:pitest-junit5-plugin:1.2.3'
+}
+
+sonar {
+	properties {
+		property 'sonar.projectKey', 'UMan-Beings_UManitobaGuessr'
+		property 'sonar.sources', 'src/main,../web/src'
+		property 'sonar.exclusions', '**/node_modules/**,**/dist/**,**/build/**,**/.gradle/**,**/gradle/**,../docs/**'
+		property 'sonar.coverage.jacoco.xmlReportPaths', 'build/reports/jacoco/test/jacocoTestReport.xml'
+		property 'sonar.typescript.tsconfigPaths', '../web/tsconfig.json'
+	}
 }
 
 tasks.named('test') {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,6 +3,7 @@ sonar.projectKey=UMan-Beings_UManitobaGuessr
 # Scan both backend and frontend source code
 sonar.sources=backend/src/main,web/src
 sonar.java.binaries=backend/build/classes/java/main
+sonar.typescript.tsconfigPaths=web/tsconfig.json
 
 # Exclusions
 sonar.exclusions=**/node_modules/**,**/dist/**,**/build/**,**/.gradle/**,**/gradle/**,docs/**


### PR DESCRIPTION
Clean up Sonar CI setup:
- switched checkout to full history (fetch-depth: 0) for Sonar.
- added frontend dependency install (pnpm install) before Sonar runs.
- sonar now runs via Gradle after backend build, so Java dependency resolution is more accurate.

Why this was done:
- Sonar was producing warnings that reduced analysis accuracy:
  - Shallow Git clone limited PR and issue tracking precision
  - Missing frontend dependencies reduced TypeScript/JS analysis quality
